### PR TITLE
refactor: replace full system prompt logging with placeholder

### DIFF
--- a/backend/src/services/langgraph-orchestrator.ts
+++ b/backend/src/services/langgraph-orchestrator.ts
@@ -547,12 +547,10 @@ export async function callClone(
     throw new Error(`Persona ${cloneId} not found in database`)
   }
 
-  // Log the FULL actual prompt being used (to prove it came from database)
+  // Log proof of database fetch without dumping the full prompt
   console.log(`[CLONE] ✓✓✓ FETCHED PERSONA ${cloneId} FROM personas TABLE ✓✓✓`)
   console.log(`[CLONE] ✓ Persona username: ${clone.reddit_username}`)
-  console.log(`[CLONE] ===== FULL PROMPT FROM DATABASE =====`)
-  console.log(clone.prompt)
-  console.log(`[CLONE] ===== END PROMPT =====`)
+  console.log(`[CLONE] ✓ System prompt for persona ${clone.reddit_username} (${clone.prompt.length} chars)`)
   console.log(`[CLONE] ${cloneId} (${clone.reddit_username}) responding with REAL DATABASE PROMPT...`)
 
   const llm = createDeepSeekLLM()


### PR DESCRIPTION
## Summary
- Remove verbose system prompt dump from stdout in `callClone()`
- Replace with placeholder showing prompt size and purpose
- Keeps proof of database fetch without cluttering logs
- Makes logs cleaner and more readable

## Motivation
System prompts can be very large (hundreds/thousands of chars), which clutters the logs unnecessarily. The placeholder still proves the prompt was fetched from the database while keeping logs readable.

## Test plan
- Backend logs should show placeholder instead of full prompt text
- Personas should still respond with full database prompts (no change to actual functionality)

🤖 Generated with [Claude Code](https://claude.com/claude-code)